### PR TITLE
Increase in the number of characters allowed for a video title

### DIFF
--- a/src/use-case/download-video/download-video.dto.ts
+++ b/src/use-case/download-video/download-video.dto.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 const containerEnum = ['mp4', 'webm', 'm4a'] as const;
 
 export const DownloadVideoRequestSchema = z.object({
-  title: z.string().nonempty().min(3).max(50),
+  title: z.string().nonempty().min(1).max(100),
   container: z.enum(containerEnum),
   itag: z.number().array().nonempty().max(2),
 });


### PR DESCRIPTION
Fixed an issue on the limit of caracteres for the video title in the download request. YouTube allow up to 100 caracters in the title of the videos uploadeds. Because that, the number os caracters allowed in the title verification, on the download-video.dto, has been increased to 100.